### PR TITLE
IR sensors are analog not digital

### DIFF
--- a/Chapter_8/CompetitiveSumoRobot.ino
+++ b/Chapter_8/CompetitiveSumoRobot.ino
@@ -125,8 +125,8 @@ void compete() {
 	// read our sensor values to determine what we
 	// need our robot to do.
 	int distance = msToCm( ping() );
-	int leftIR   = digitalRead(leftSensor);
-	int rightIR  = digitalRead(rightSensor);
+	int leftIR   = analogRead(leftSensor);
+	int rightIR  = analogRead(rightSensor);
 
 	if ( leftIR < abortThreshold || rightIR < abortThreshold ) {
 		// if we have detected a ring border, abort!


### PR DESCRIPTION
Changes the command used to read the IR sensors to analogRead as necessary for the IRsensor circuitry.  The analog approach is also simpler for a student to understand because it is simply the conversion of a variable voltage to a 10-bit integer (a number from 0 to 1023) that corresponds to the voltage.  The digital approach requires circuitry with a capacitor and requires writing code to capture how long it takes the capacitor to switch from high to low voltage.